### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+type: software
+title: "TidalPy: Software Suite for Solving Problems in Tidal Dynamics"
+authors:
+  - family-names: "Renaud"
+    given-names: "Joe"
+    orcid: "https://orcid.org/0000-0002-8619-8542"
+repository-code: "https://github.com/jrenaud90/TidalPy"
+license: "Apache-2.0"
+version: "0.7.4"


### PR DESCRIPTION
JOSS reviewers ask for a `CITATION.cff`, and this repository does not have one yet.

Generated from the author list in `origin:Papers/2025-JOSS/paper.md`: 1 author(s), with given and family names taken from each author's ORCID record rather than split from the display name, because compound surnames do not split reliably.

`license` is `Apache-2.0`, read from the LICENSE file. `version` is `0.7.4`, the newest release tag. 

Verified with `cffconvert --validate`: valid against schema 1.2.0.